### PR TITLE
Add a type NumericTime to make sorting possible without performance tradeoffs

### DIFF
--- a/mapping_properties_builder.go
+++ b/mapping_properties_builder.go
@@ -149,7 +149,7 @@ func (b *MappingPropertiesBuilder) resolveFieldType(field *fieldWrapper) (string
 	}
 	if field.kind == reflect.Struct {
 		if x, ok := field.value.Interface().(OpenSearchDateType); ok {
-			if x.GetOpenSearchFieldType() != "" {
+			if x.GetOpenSearchDateFieldType() != "" {
 				return "date", nil
 			}
 		}
@@ -164,8 +164,8 @@ func (b *MappingPropertiesBuilder) resolveFieldFormat(field *fieldWrapper) (*str
 	}
 	if field.kind == reflect.Struct {
 		if x, ok := field.value.Interface().(OpenSearchDateType); ok {
-			if x.GetOpenSearchFieldType() != "" {
-				return MakePtr(x.GetOpenSearchFieldType()), nil
+			if x.GetOpenSearchDateFieldType() != "" {
+				return MakePtr(x.GetOpenSearchDateFieldType()), nil
 			}
 		}
 	}

--- a/time_formats.go
+++ b/time_formats.go
@@ -1,17 +1,16 @@
 package opensearchutil
 
 import (
+	"encoding/json"
 	"time"
 
-	"encoding/json"
-	
+	"github.com/pkg/errors"
 )
 
 const (
 	FormatTimeBasicDateTime         = "20060102T150405.999-07:00"
 	FormatTimeBasicDateTimeNoMillis = "20060102T150405-07:00"
 	FormatTimeBasicDate             = "20060102"
-	FormatTimestamp64               = "epoch_second"
 )
 
 type (

--- a/time_formats.go
+++ b/time_formats.go
@@ -4,12 +4,14 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"strconv"
 )
 
 const (
 	FormatTimeBasicDateTime         = "20060102T150405.999-07:00"
 	FormatTimeBasicDateTimeNoMillis = "20060102T150405-07:00"
 	FormatTimeBasicDate             = "20060102"
+	FormatEpochSecond               = "epoch_second"
 )
 
 type (
@@ -21,6 +23,9 @@ type (
 
 	// TimeBasicDate marshalls into OpenSearch basic_date type
 	TimeBasicDate time.Time
+
+	// TimeEpochSecond marshals into OpenSearch epoch_second type
+	TimeEpochSecond time.Time
 )
 
 // OpenSearchDateType tells MappingPropertiesBuilder that a type is a "date" OpenSearch type.
@@ -90,4 +95,27 @@ func (t *TimeBasicDate) UnmarshalText(text []byte) error {
 //goland:noinspection GoMixedReceiverTypes
 func (t TimeBasicDate) GetOpenSearchFieldType() string {
 	return "basic_date"
+}
+
+// TimeEpochSecond
+
+// MarshalText implements the encoding.TextMarshaler interface for TimeEpochSecond.
+func (t TimeEpochSecond) MarshalText() ([]byte, error) {
+	epochSeconds := time.Time(t).Unix()
+	return []byte(strconv.FormatInt(epochSeconds, 10)), nil
+}
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface for TimeEpochSecond.
+func (t *TimeEpochSecond) UnmarshalText(text []byte) error {
+	epochSeconds, err := strconv.ParseInt(string(text), 10, 64)
+	if err != nil {
+		return errors.Wrap(err, "strconv.ParseInt")
+	}
+	*t = TimeEpochSecond(time.Unix(epochSeconds, 0))
+	return nil
+}
+
+// GetOpenSearchFieldType returns the OpenSearch field type for TimeEpochSecond.
+func (t TimeEpochSecond) GetOpenSearchFieldType() string {
+	return FormatEpochSecond
 }

--- a/time_formats.go
+++ b/time_formats.go
@@ -132,3 +132,8 @@ func (nt *NumericTime) UnmarshalJSON(data []byte) error {
 func (nt NumericTime) Unix() int64 {
 	return nt.Time.Unix()
 }
+
+// NewTimeNumericTime is a constructor for NumericTime.
+func NewTimeNumericTime(t time.Time) NumericTime {
+	return NumericTime{t}
+}

--- a/time_formats.go
+++ b/time_formats.go
@@ -44,7 +44,7 @@ type (
 
 // OpenSearchDateType tells MappingPropertiesBuilder that a type is a "date" OpenSearch type.
 type OpenSearchDateType interface {
-	GetOpenSearchFieldType() string
+	GetOpenSearchDateFieldType() string
 }
 
 //goland:noinspection GoMixedReceiverTypes
@@ -63,7 +63,7 @@ func (t *TimeBasicDateTime) UnmarshalText(text []byte) error {
 }
 
 //goland:noinspection GoMixedReceiverTypes
-func (t TimeBasicDateTime) GetOpenSearchFieldType() string {
+func (t TimeBasicDateTime) GetOpenSearchDateFieldType() string {
 	return "basic_date_time"
 }
 
@@ -85,7 +85,7 @@ func (t *TimeBasicDateTimeNoMillis) UnmarshalText(text []byte) error {
 }
 
 //goland:noinspection GoMixedReceiverTypes
-func (t TimeBasicDateTimeNoMillis) GetOpenSearchFieldType() string {
+func (t TimeBasicDateTimeNoMillis) GetOpenSearchDateFieldType() string {
 	return "basic_date_time_no_millis"
 }
 
@@ -107,7 +107,7 @@ func (t *TimeBasicDate) UnmarshalText(text []byte) error {
 }
 
 //goland:noinspection GoMixedReceiverTypes
-func (t TimeBasicDate) GetOpenSearchFieldType() string {
+func (t TimeBasicDate) GetOpenSearchDateFieldType() string {
 	return "basic_date"
 }
 

--- a/time_formats_test.go
+++ b/time_formats_test.go
@@ -88,3 +88,44 @@ func TestTimeFormat_marshallingIntoJson(t *testing.T) {
 	g.Expect(time.Time(fooUnmarshalled.B).Equal(time.Date(2019, 3, 23, 21, 34, 46, 0, time.UTC))).To(BeTrue())
 	g.Expect(time.Time(fooUnmarshalled.C).Equal(time.Date(2019, 3, 23, 0, 0, 0, 0, time.UTC))).To(BeTrue())
 }
+
+func TestNumericTime_MarshalJSON(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	customTime := NumericTime{Time: time.Date(2023, 1, 7, 15, 0, 0, 0, time.UTC)}
+	jsonBytes, err := json.Marshal(customTime)
+	g.Expect(err).To(BeNil())
+	g.Expect(string(jsonBytes)).To(Equal("1673103600")) // Unix timestamp for 2023-01-07 15:00:00 UTC
+}
+
+func TestNumericTime_UnmarshalJSON(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	var customTime NumericTime
+	err := json.Unmarshal([]byte("1673103600"), &customTime)
+	g.Expect(err).To(BeNil())
+	g.Expect(customTime.Time.Equal(time.Date(2023, 1, 7, 15, 0, 0, 0, time.UTC))).To(BeTrue())
+}
+
+func TestNumericTime_JSONMarshallingAndUnmarshalling(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	type TestStruct struct {
+		Timestamp NumericTime `json:"timestamp"`
+	}
+
+	// Original time for testing
+	originalTime := time.Date(2023, 1, 7, 15, 0, 0, 0, time.UTC)
+	testObj := TestStruct{Timestamp: NumericTime{Time: originalTime}}
+
+	// Marshal the struct
+	jsonBytes, err := json.Marshal(testObj)
+	g.Expect(err).To(BeNil())
+	g.Expect(string(jsonBytes)).To(Equal(`{"timestamp":1673103600}`))
+
+	// Unmarshal back into a struct
+	var unmarshalledObj TestStruct
+	err = json.Unmarshal(jsonBytes, &unmarshalledObj)
+	g.Expect(err).To(BeNil())
+	g.Expect(unmarshalledObj.Timestamp.Time.Equal(originalTime)).To(BeTrue())
+}


### PR DESCRIPTION
OpenSearch 2.17 indexes "date" fields (even with format=epoch_seconds) as text:
```
                            "type": "text",
                            "fields": {
                                "keyword": {
                                    "type": "keyword",
                                    "ignore_above": 256
                                }
                            }
```

Sorting on such a field gives:
```
Text fields are not optimised for operations that require per-document field data like aggregations and sorting, so these operations are disabled by default. Please use a keyword field instead. Alternatively, set fielddata=true on [<field name>] in order to load field data by uninverting the inverted index. Note that this can use significant memory.
```
